### PR TITLE
Add user login w/o twitter. Fix tests for both login methods.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'puma'
 gem 'omniauth-twitter'
 gem 'pry'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Unicorn as the app server
 # gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
+    bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -197,6 +198,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   byebug
   capybara
   coffee-rails (~> 4.1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,5 +8,5 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
-  
+
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,10 +1,21 @@
 class SessionsController < ApplicationController
 
+  def new
+  end
+
   def create
-    if user = User.from_omniauth(request.env["omniauth.auth"])
-      session[:user_id] = user.id
+    if request.env["omniauth.auth"]
+      @user = User.from_omniauth(request.env["omniauth.auth"])
+      @user.save
+    else
+      @user = User.find_by(name: params[:session][:name])
     end
-    redirect_to root_path
+    if @user && (@user.provider || @user.authenticate(params[:session][:password]))
+      session[:user_id] ||= @user.id
+      redirect_to user_path(@user)
+    else
+      redirect_to root_path
+    end
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :summoner_name, :region)
+    params.require(:user).permit(:name, :summoner_name, :region, :password, :password_confirmation)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,16 @@
 class User < ActiveRecord::Base
+  has_secure_password
 
   def self.from_omniauth(auth_info)
-    where(uid: auth_info[:uid]).first_or_create do |new_user|
-      new_user.uid                = auth_info.uid
+    find_or_create_by(uid: auth_info[:extra][:raw_info][:user_id]) do |new_user|
+      new_user.uid                = auth_info.extra.raw_info.user_id
       new_user.name               = auth_info.extra.raw_info.name
       new_user.screen_name        = auth_info.extra.raw_info.screen_name
       new_user.oauth_token        = auth_info.credentials.token
       new_user.oauth_token_secret = auth_info.credentials.secret
+      new_user.provider           = auth_info.provider
+      new_user.password           = "password"
     end
   end
+
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,9 @@
+<%= form_for(:session, url: login_path) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+
+  <%= f.submit "Login" %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -8,5 +8,11 @@
   <%= f.label :region %>
   <%= f.text_field :region %>
 
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+
+  <%= f.label :password_confirmation, "Password Confirmation" %>
+  <%= f.password_field :password_confirmation %>
+
   <%= f.submit "Create Account" %>
 <% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -6,5 +6,5 @@
 <% else %>
   <%= link_to "Login", new_session_path %>
   <%= link_to "Create Account", new_user_path %>
-  <%= link_to "Login with Twitter", login_path %>
+  <%= link_to "Login with Twitter", twitter_login_path %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,10 @@
 Rails.application.routes.draw do
 
-  get 'dashboards/index'
-
   root to: 'welcome#index'
-  get '/auth/twitter', as: :login
+  get '/auth/twitter', as: :twitter_login
   get '/auth/twitter/callback', to: 'sessions#create'
   get '/logout', to: 'sessions#destroy', as: :logout
+  post '/login', to: 'sessions#create'
 
   resources :users, only: [:new, :create, :show]
   resources :sessions, only: [:new, :create, :destroy]

--- a/db/migrate/20160229201008_create_users.rb
+++ b/db/migrate/20160229201008_create_users.rb
@@ -6,6 +6,7 @@ class CreateUsers < ActiveRecord::Migration
       t.string :uid
       t.string :oauth_token
       t.string :oauth_token_secret
+      t.string :provider
 
       t.timestamps null: false
     end

--- a/db/migrate/20160229232704_add_password_to_users.rb
+++ b/db/migrate/20160229232704_add_password_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229210018) do
+ActiveRecord::Schema.define(version: 20160229232704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,10 +22,12 @@ ActiveRecord::Schema.define(version: 20160229210018) do
     t.string   "uid"
     t.string   "oauth_token"
     t.string   "oauth_token_secret"
+    t.string   "provider"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
     t.string   "summoner_name"
     t.string   "region"
+    t.string   "password_digest"
   end
 
 end

--- a/spec/features/guest_can_create_account_spec.rb
+++ b/spec/features/guest_can_create_account_spec.rb
@@ -11,6 +11,8 @@ RSpec.feature "GuestCanCreateAccount", type: :feature do
     fill_in "Name", with: "Gregory Armstrong"
     fill_in "Summoner Name", with: "OctopusMachine"
     fill_in "Region", with: "NA"
+    fill_in "Password", with: "password"
+    fill_in "Password Confirmation", with: "password"
     click_on("Create Account")
 
     user = User.last

--- a/spec/features/user_can_login_spec.rb
+++ b/spec/features/user_can_login_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.feature "UserCanLogin", type: :feature do
+  scenario "registered user can log in" do
+    user = User.create(name: "Greg Armstrong",
+                       summoner_name: "OctopusMachine",
+                       region: "NA",
+                       password: "password"
+                       )
+    visit root_path
+
+    click_link "Login"
+
+    expect(current_path).to eq new_session_path
+
+    fill_in "Name", with: "Greg Armstrong"
+    fill_in "Password", with: "password"
+    click_on("Login")
+
+    user = User.last
+
+    expect(current_path).to eq user_path(user)
+    expect(page).to have_content("Greg Armstrong")
+    expect(page).to have_content("OctopusMachine")
+    expect(page).to have_content("NA")
+  end
+end

--- a/spec/features/user_can_logout_spec.rb
+++ b/spec/features/user_can_logout_spec.rb
@@ -11,6 +11,8 @@ RSpec.feature "UserCanLogout", type: :feature do
     fill_in "Name", with: "Gregory Armstrong"
     fill_in "Summoner Name", with: "OctopusMachine"
     fill_in "Region", with: "NA"
+    fill_in "Password", with: "password"
+    fill_in "Password Confirmation", with: "password"
     click_on("Create Account")
 
     user = User.last

--- a/spec/features/user_logs_in_with_twitters_spec.rb
+++ b/spec/features/user_logs_in_with_twitters_spec.rb
@@ -9,7 +9,9 @@ RSpec.feature "UserLogsInWithTwitters", type: :feature do
 
     click_link "Login with Twitter"
 
-    expect(current_path).to eq root_path
+    user = User.last
+
+    expect(current_path).to eq user_path(user)
     expect(page).to have_content("Gregory Armstrong")
   end
 end


### PR DESCRIPTION
Added user login for an account not authenticated with twitter. Users controller
and sessions controller can now deal with either a twitter-oauth user or a user
who registers with the site normally. All tests fixed to handle the changes associated
and all are passing.
