### PR TITLE
Add form to twitter-oauth-user dashboard for summoner name/region

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,16 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    @user.update(user_params)
+    redirect_to user_path(@user)
+  end
+
   private
 
   def user_params

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,9 @@
+<%= form_for(:user, url: user_path(@user), method: :put ) do |f| %>
+  <%= f.label :summoner_name, "Summoner Name" %>
+  <%= f.text_field :summoner_name %>
+
+  <%= f.label :region %>
+  <%= f.text_field :region %>
+
+  <%= f.submit "Update" %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,7 @@
 <%= link_to "Logout", logout_path %>
+<% if current_user && current_user.summoner_name == nil %>
+  <%= link_to "Add Summoner Name/Region", edit_user_path(session[:user_id]) %>
+<% end %>
 
 <h1><%= @user.name %>'s Dashboard</h1>
 <h2><%= @user.summoner_name %></h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#destroy', as: :logout
   post '/login', to: 'sessions#create'
 
-  resources :users, only: [:new, :create, :show]
+  resources :users, only: [:new, :create, :show, :update, :edit]
   resources :sessions, only: [:new, :create, :destroy]
 
 end

--- a/spec/features/user_logs_in_with_twitters_spec.rb
+++ b/spec/features/user_logs_in_with_twitters_spec.rb
@@ -14,4 +14,28 @@ RSpec.feature "UserLogsInWithTwitters", type: :feature do
     expect(current_path).to eq user_path(user)
     expect(page).to have_content("Gregory Armstrong")
   end
+
+  scenario "guest who has registered via twitter oauth can add summoner name/region" do
+    visit root_path
+
+    click_link "Login with Twitter"
+
+    user = User.last
+
+    expect(current_path).to eq user_path(user)
+
+    expect(page).to have_content("Gregory Armstrong")
+    expect(page).to_not have_content("OctopusMachine")
+    expect(page).to_not have_content("NA")
+
+    click_link "Add Summoner Name/Region"
+
+    fill_in "Summoner Name", with: "OctopusMachine"
+    fill_in "Region", with: "NA"
+    click_on("Update")
+
+    expect(current_path).to eq user_path(user)
+    expect(page).to have_content("OctopusMachine")
+    expect(page).to have_content("NA")
+  end
 end


### PR DESCRIPTION
Added a link to the dashboard of a twitter-oauth-user to be able to add in their
league of legends summoner name and region. User controller correctly updates
these fields for the user and returns them to the dashboard. All tests passing.
